### PR TITLE
Bump modules to TF 0.13 compatible versions

### DIFF
--- a/examples/http-load-balancer-website/main.tf
+++ b/examples/http-load-balancer-website/main.tf
@@ -27,7 +27,7 @@ provider "google-beta" {
 module "static_site" {
   # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
   # to a specific version of the modules, such as the following example:
-  # source = "github.com/gruntwork-io/terraform-google-static-assets.git//modules/http-load-balancer-website?ref=v0.1.1"
+  # source = "github.com/gruntwork-io/terraform-google-static-assets.git//modules/http-load-balancer-website?ref=v0.3.0"
   source = "../../modules/http-load-balancer-website"
 
   project = var.project

--- a/modules/http-load-balancer-website/main.tf
+++ b/modules/http-load-balancer-website/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "load_balancer" {
-  source = "github.com/gruntwork-io/terraform-google-load-balancer.git//modules/http-load-balancer?ref=v0.2.2"
+  source = "github.com/gruntwork-io/terraform-google-load-balancer.git//modules/http-load-balancer?ref=v0.3.0"
 
   name                  = local.website_domain_name_dashed
   project               = var.project


### PR DESCRIPTION
This PR should have been included in the TF 0.13 release. It ensures dependent modules are using TF 0.13 compatible versions.