### PR TITLE
Allows the creation of Google managed certificate

### DIFF
--- a/modules/http-load-balancer-website/README.md
+++ b/modules/http-load-balancer-website/README.md
@@ -55,3 +55,17 @@ See https://cloud.google.com/storage/docs/encryption/.
 If you are using your Cloud Storage bucket for both the `www.` and root domain of a website (e.g. `www.foo.com` and `foo.com`),
 you can create [Synthetic records](https://support.google.com/domains/answer/6069273?hl=en) with 
 [Subdomain forwarding](https://support.google.com/domains/answer/6072198).
+
+## How do I create signed URLs?
+
+Set variable `enable_signed_urls` to `true`. By default, the module will create a random 16 bytes string to use as key to sign 
+URLs. You can retrieve the key using `terraform output -raw sign_key`. If you want to use your own key, you can set it using 
+variable `signed_url_key`, and the command:
+
+```bash
+head -c 16 /dev/urandom | base64 | tr +/ -_
+```
+
+For security reasons, you have to disable `allUsers` access as ACL, and setup Cloud CDN service account as _Object Viewer_.
+
+[Google Documentation of Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls).

--- a/modules/http-load-balancer-website/main.tf
+++ b/modules/http-load-balancer-website/main.tf
@@ -18,6 +18,7 @@ locals {
   # We have to use dashes instead of dots in the bucket name, because
   # that bucket is not a website
   website_domain_name_dashed = replace(var.website_domain_name, ".", "-")
+  sign_key_output            = var.signed_url_key == "" && var.enable_signed_url ? random_id.url_signature[0].b64_std : var.signed_url_key
 }
 
 module "load_balancer" {
@@ -100,4 +101,21 @@ module "site_bucket" {
   create_dns_entry = false
 
   custom_labels = var.custom_labels
+}
+
+# ------------------------------------------------------------------------------
+# CREATE SIGNED URL KEY
+# ------------------------------------------------------------------------------
+
+resource "random_id" "url_signature" {
+  count       = var.signed_url_key == "" && var.enable_signed_url ? 1 : 0
+  byte_length = 16
+}
+
+resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
+  count          = var.enable_signed_url ? 1 : 0
+  name           = "signing-key"
+  project        = var.project
+  key_value      = var.signed_url_key == "" ? random_id.url_signature[0].b64_url : var.signed_url_key
+  backend_bucket = google_compute_backend_bucket.static.name
 }

--- a/modules/http-load-balancer-website/outputs.tf
+++ b/modules/http-load-balancer-website/outputs.tf
@@ -28,3 +28,8 @@ output "access_logs_bucket_name" {
   value       = module.site_bucket.access_logs_bucket_name
 }
 
+output "sign_key" {
+  description = "Key used to sign URLs"
+  value       = var.enable_signed_url ? local.sign_key_output : null
+  sensitive   = true
+}

--- a/modules/http-load-balancer-website/variables.tf
+++ b/modules/http-load-balancer-website/variables.tf
@@ -167,3 +167,14 @@ variable "custom_labels" {
   default     = {}
 }
 
+variable "signed_url_key" {
+  description = "An string of at least 16 bytes to create the signing key."
+  type        = string
+  default     = ""
+}
+
+variable "enable_signed_url" {
+  description = "Whether to use signed urls."
+  type        = bool
+  default     = false
+}

--- a/modules/http-load-balancer-website/variables.tf
+++ b/modules/http-load-balancer-website/variables.tf
@@ -41,6 +41,12 @@ variable "enable_versioning" {
   default     = true
 }
 
+variable "create_certificate" {
+  description = "Set to true to create a SSL certificate managed by Google"
+  type        = bool
+  default     = true
+}
+
 variable "enable_ssl" {
   description = "Set to true to enable ssl. If set to 'true', you will also have to provide 'var.ssl_certificate'."
   type        = bool


### PR DESCRIPTION
Quick addition to allow the creation of a Google Managed certificate to attach to the HTTPS load balancer.