### PR TITLE
Add ability to create signed URLs with CDN

### DIFF
--- a/modules/cloud-storage-static-website/main.tf
+++ b/modules/cloud-storage-static-website/main.tf
@@ -33,9 +33,10 @@ resource "google_storage_bucket" "website" {
 
   project = var.project
 
-  name          = var.website_domain_name
-  location      = var.website_location
-  storage_class = var.website_storage_class
+  name                        = var.website_domain_name
+  location                    = var.website_location
+  storage_class               = var.website_storage_class
+  uniform_bucket_level_access = var.uniform_bucket_level_access
 
   versioning {
     enabled = var.enable_versioning

--- a/modules/cloud-storage-static-website/variables.tf
+++ b/modules/cloud-storage-static-website/variables.tf
@@ -143,3 +143,8 @@ variable "custom_labels" {
   default     = {}
 }
 
+variable "uniform_bucket_level_access" {
+  default     = false
+  description = "Enable uniform bucket level access (default: false)"
+  type        = string
+}

--- a/modules/http-load-balancer-website/README.md
+++ b/modules/http-load-balancer-website/README.md
@@ -55,3 +55,17 @@ See https://cloud.google.com/storage/docs/encryption/.
 If you are using your Cloud Storage bucket for both the `www.` and root domain of a website (e.g. `www.foo.com` and `foo.com`),
 you can create [Synthetic records](https://support.google.com/domains/answer/6069273?hl=en) with 
 [Subdomain forwarding](https://support.google.com/domains/answer/6072198).
+
+## How do I create signed URLs?
+
+Set variable `enable_signed_urls` to `true`. By default, the module will create a random 16 bytes string to use as key to sign 
+URLs. You can retrieve the key using `terraform output -raw sign_key`. If you want to use your own key, you can set it using 
+variable `signed_url_key`, and the command:
+
+```bash
+head -c 16 /dev/urandom | base64 | tr +/ -_
+```
+
+For security reasons, you have to disable `allUsers` access as ACL, and setup Cloud CDN service account as _Object Viewer_.
+
+[Google Documentation of Signed URLs](https://cloud.google.com/cdn/docs/using-signed-urls).

--- a/modules/http-load-balancer-website/main.tf
+++ b/modules/http-load-balancer-website/main.tf
@@ -18,6 +18,7 @@ locals {
   # We have to use dashes instead of dots in the bucket name, because
   # that bucket is not a website
   website_domain_name_dashed = replace(var.website_domain_name, ".", "-")
+  sign_key_output            = var.signed_url_key == "" && var.enable_signed_url ? random_id.url_signature[0].b64_std : var.signed_url_key
 }
 
 module "load_balancer" {
@@ -100,4 +101,21 @@ module "site_bucket" {
   create_dns_entry = false
 
   custom_labels = var.custom_labels
+}
+
+# ------------------------------------------------------------------------------
+# CREATE SIGNED URL KEY
+# ------------------------------------------------------------------------------
+
+resource "random_id" "url_signature" {
+  count       = var.signed_url_key == "" && var.enable_signed_url ? 1 : 0
+  byte_length = 16
+}
+
+resource "google_compute_backend_bucket_signed_url_key" "backend_key" {
+  count          = var.enable_signed_url ? 1 : 0
+  name           = "signing-key"
+  project        = var.project
+  key_value      = var.signed_url_key == "" ? random_id.url_signature[0].b64_url : var.signed_url_key
+  backend_bucket = google_compute_backend_bucket.static.name
 }

--- a/modules/http-load-balancer-website/main.tf
+++ b/modules/http-load-balancer-website/main.tf
@@ -73,11 +73,12 @@ module "site_bucket" {
 
   project = var.project
 
-  website_domain_name   = local.website_domain_name_dashed
-  website_acls          = var.website_acls
-  website_location      = var.website_location
-  website_storage_class = var.website_storage_class
-  force_destroy_website = var.force_destroy_website
+  website_domain_name         = local.website_domain_name_dashed
+  website_acls                = var.website_acls
+  website_location            = var.website_location
+  website_storage_class       = var.website_storage_class
+  force_destroy_website       = var.force_destroy_website
+  uniform_bucket_level_access = var.uniform_bucket_level_access
 
   index_page     = var.index_page
   not_found_page = var.not_found_page

--- a/modules/http-load-balancer-website/outputs.tf
+++ b/modules/http-load-balancer-website/outputs.tf
@@ -28,3 +28,8 @@ output "access_logs_bucket_name" {
   value       = module.site_bucket.access_logs_bucket_name
 }
 
+output "sign_key" {
+  description = "Key used to sign URLs"
+  value       = var.enable_signed_url ? local.sign_key_output : null
+  sensitive   = true
+}

--- a/modules/http-load-balancer-website/outputs.tf
+++ b/modules/http-load-balancer-website/outputs.tf
@@ -28,8 +28,13 @@ output "access_logs_bucket_name" {
   value       = module.site_bucket.access_logs_bucket_name
 }
 
-output "sign_key" {
+output "sign_key_secret" {
   description = "Key used to sign URLs"
   value       = var.enable_signed_url ? local.sign_key_output : null
   sensitive   = true
+}
+
+output "sign_key_name" {
+  description = "Key used to sign URLs"
+  value       = var.enable_signed_url ? google_compute_backend_bucket_signed_url_key.backend_key[0].name : null
 }

--- a/modules/http-load-balancer-website/variables.tf
+++ b/modules/http-load-balancer-website/variables.tf
@@ -178,3 +178,9 @@ variable "enable_signed_url" {
   type        = bool
   default     = false
 }
+
+variable "uniform_bucket_level_access" {
+  default     = false
+  description = "Enable uniform bucket level access (default: false)"
+  type        = string
+}

--- a/modules/http-load-balancer-website/variables.tf
+++ b/modules/http-load-balancer-website/variables.tf
@@ -167,3 +167,14 @@ variable "custom_labels" {
   default     = {}
 }
 
+variable "signed_url_key" {
+  description = "An string of at least 16 bytes to create the signing key."
+  type        = string
+  default     = ""
+}
+
+variable "enable_signed_url" {
+  description = "Whether to use signed urls."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

With these changes, module will be able to create a CDN with signed URLs enabled.

### Documentation

Two variables added to control signed URLs configuration: `enable_signed_url` and `signed_url_key`. If the second one is not configured, a random 16 bytes string will be used as secret.

`sign_key` is the output containing the signed URL key, marked as sensitive:

```hcl
module "private_cdn" {
  source = "./modules/http-load-balancer-website"
[...]
   enable_signed_url = true
[...]
}
```

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [X] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [X] Update the docs.
- [X] Keep the changes backward compatible where possible.
- [X] Run the pre-commit checks successfully.
- [X] Run the relevant tests successfully.